### PR TITLE
feat: improve php format string detection

### DIFF
--- a/src/PoDomain.php
+++ b/src/PoDomain.php
@@ -8,6 +8,10 @@ class PoDomain
     protected array $messages = [];
     protected ?string $comment_tag;
 
+    // regex to detect a php sprintf string, we only exclude the space flag
+    // because that is the default and the most likely to raise false positives
+    //                            %|argnum$|flags_|w_|precision___|specifier________
+    private string $fmt_regex = '/%(\d+\$)?[+0#-]*\d*(\.\d+|\.\*)?[bcdeEfFgGhHosuxX]/';
 
     public function __construct(?string $comment_tag = null, int $line_length = 80)
     {
@@ -30,7 +34,7 @@ class PoDomain
         );
 
         // add php-format flag if needed
-        if (false !== strpos($msguid, '%')) {
+        if (preg_match($this->fmt_regex, $msguid)) {
             $flag = 'php-format';
             if (isset($msg['#,'])) {
                 if (false === strpos($msg['#,'], $flag)) {

--- a/tests/PoDomainTest.php
+++ b/tests/PoDomainTest.php
@@ -66,6 +66,24 @@ print_r("$po");
                     'TRAD:',
                     ['msgid' => 'An apple', '#.' => ['/*** TRAD: comment1 */', '/// comment2', '### comment3']]
                 ],
+            'POT with complex float sprintf' =>
+                [
+                    '/#, php-format\s+msgid "%0.2f apple/',
+                    '',
+                    ['msgid' => '%0.2f apple']
+                ],
+            'POT with complex string sprintf' =>
+                [
+                    '/#, php-format\s+msgid "%-200s apple/',
+                    '',
+                    ['msgid' => '%-200s apple']
+                ],
+            'POT with non-sprintf %' =>
+                [
+                    '/msgid "% of an apple is 100%, not 90% orange/',
+                    '',
+                    ['msgid' => '% of an apple is 100%, not 90% orange']
+                ],
         ];
     }
 }


### PR DESCRIPTION
Use a regex to detect sprintf-formatted strings. This catches many fewer false positives. Fixes #1

I was able to successfully run the unit tests by adding a `tests/phpunit.xml` file, which might be useful to include in the repo as well:
```xml
<?xml version="1.0" encoding="UTF-8"?>

<phpunit bootstrap = "../vendor/autoload.php"
    colors        = "false"
    stopOnFailure = "false"
    verbose       = "true">

    <testsuites>
        <testsuite name="Tests">
            <directory>.</directory>
        </testsuite>
    </testsuites>
</phpunit>
```

You might consider adding this