### PR TITLE
Extract strings from user-created pgettext functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,7 +550,8 @@ Example:
   echo $anotherDomain->_("Welcome to Another PHP Application"), "\n";
   ```
 
-Also, context-aware functions (`pgettext` family) are missing from bundled PHP gettext extension.
+Also, while context-aware functions (`pgettext` family) are missing from bundled PHP gettext extension,
+`xtext` will extract strings from similarly-named functions when possible.
 
 ## Resources
 

--- a/bin/xtext
+++ b/bin/xtext
@@ -175,6 +175,7 @@ class Php2PoVisitor extends NodeVisitorAbstract
                     }
                     break;
                 case 'pget':
+                case 'pgettext':
                     // arguments: 1c,2
                     $msgctxt = $this->stringArg($node->args[0]->value);
                     $msgid = $this->stringArg($node->args[1]->value);


### PR DESCRIPTION
While the gettext PHP extension doesn't have a `pgettext()` function, it's trivial to add one that replicates it, eg: https://www.php.net/manual/en/book.gettext.php#89975 and we have done so at DProofreaders.

In the case that the codebase has one and uses it, extract the context-aware strings from it. This seems like a pretty safe approach as why would someone create a function called `pgettext()` if they weren't trying to replicate what the C-API one did.

While we at DProofreaders haven't created and used an `npgettext()` version it would be simple to have `xtext` support it too in the case statement.